### PR TITLE
Add core gameplay scripts

### DIFF
--- a/Assets/Scripts/Cell.cs
+++ b/Assets/Scripts/Cell.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+/// <summary>
+/// Represents a single cell in the game grid.
+/// Each cell can hold at most one Drop.
+/// </summary>
+public class Cell : MonoBehaviour
+{
+    /// <summary>
+    /// Grid coordinates of this cell (X = column, Y = row).
+    /// </summary>
+    public Vector2Int Coordinates { get; set; }
+
+    /// <summary>
+    /// The drop currently placed on this cell. Null if the cell is empty.
+    /// </summary>
+    public Drop CurrentDrop { get; private set; }
+
+    /// <summary>
+    /// True when a drop occupies the cell.
+    /// </summary>
+    public bool IsOccupied => CurrentDrop != null;
+
+    /// <summary>
+    /// Assigns a drop to the cell.
+    /// </summary>
+    public void SetDrop(Drop drop)
+    {
+        CurrentDrop = drop;
+    }
+
+    /// <summary>
+    /// Clears the reference to the drop.
+    /// </summary>
+    public void Clear()
+    {
+        CurrentDrop = null;
+    }
+}

--- a/Assets/Scripts/Drop.cs
+++ b/Assets/Scripts/Drop.cs
@@ -1,0 +1,60 @@
+using UnityEngine;
+
+/// <summary>
+/// Component that stores the numeric value of a drop and handles fusion.
+/// </summary>
+public class Drop : MonoBehaviour
+{
+    [SerializeField] private Animator animator; // Plays fusion animation
+
+    /// <summary>
+    /// Current numeric value of the drop.
+    /// </summary>
+    public int Value { get; private set; }
+
+    /// <summary>
+    /// The cell the drop is currently occupying.
+    /// </summary>
+    public Cell CurrentCell { get; private set; }
+
+    /// <summary>
+    /// Initializes the drop with a starting value and parent cell.
+    /// </summary>
+    public void Initialize(int value, Cell cell)
+    {
+        Value = value;
+        MoveTo(cell);
+    }
+
+    /// <summary>
+    /// Moves the drop to another cell.
+    /// </summary>
+    public void MoveTo(Cell cell)
+    {
+        if (CurrentCell != null)
+            CurrentCell.Clear();
+
+        CurrentCell = cell;
+        if (cell != null)
+        {
+            cell.SetDrop(this);
+            transform.position = cell.transform.position;
+        }
+    }
+
+    /// <summary>
+    /// Fuses this drop with another, increasing the value and destroying the other.
+    /// </summary>
+    public void FuseWith(Drop other)
+    {
+        if (other == null || other == this)
+            return;
+
+        Value += other.Value;
+        if (animator != null)
+            animator.SetTrigger("Fuse");
+
+        Destroy(other.gameObject);
+        GameManager.Instance.RegisterFusion(Value);
+    }
+}

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,0 +1,69 @@
+using UnityEngine;
+
+/// <summary>
+/// Central controller for basic game state and score handling.
+/// </summary>
+public class GameManager : MonoBehaviour
+{
+    public static GameManager Instance { get; private set; }
+
+    [Header("Managers")]
+    [SerializeField] private GridManager gridManager;
+    [SerializeField] private InterstitialAds interstitialAds;
+    [SerializeField] private AudioManager audioManager;
+
+    [Header("Settings")]
+    [SerializeField, Range(4, 5)] private int gridSize = 4;
+    [SerializeField] private AudioClip fusionClip;
+
+    private int score;
+    private int fusions;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+    }
+
+    private void Start()
+    {
+        if (gridManager != null)
+            gridManager.CreateGrid(gridSize);
+    }
+
+    /// <summary>
+    /// Called by a drop when a fusion occurs.
+    /// Adds to the score and optionally plays audio/ads.
+    /// </summary>
+    public void RegisterFusion(int valueGained)
+    {
+        score += valueGained;
+        fusions++;
+        if (audioManager != null && fusionClip != null)
+            audioManager.PlaySFX(fusionClip);
+
+        // Show an interstitial every 10 fusions as an example.
+        if (fusions % 10 == 0 && interstitialAds != null)
+            interstitialAds.ShowAd();
+    }
+
+    /// <summary>
+    /// Returns the current score.
+    /// </summary>
+    public int GetScore() => score;
+
+    /// <summary>
+    /// Restarts the game by clearing and recreating the grid and resetting score.
+    /// </summary>
+    public void RestartGame()
+    {
+        score = 0;
+        fusions = 0;
+        if (gridManager != null)
+            gridManager.CreateGrid(gridSize);
+    }
+}

--- a/Assets/Scripts/GridManager.cs
+++ b/Assets/Scripts/GridManager.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Responsible for creating the grid of cells and spawning drops.
+/// </summary>
+public class GridManager : MonoBehaviour
+{
+    [SerializeField] private Cell cellPrefab;
+    [SerializeField] private Drop dropPrefab;
+    [SerializeField] private Transform gridRoot;
+
+    private int gridSize;
+    private Cell[,] cells;
+
+    /// <summary>
+    /// Create a new grid. Old cells are destroyed.
+    /// </summary>
+    public void CreateGrid(int size)
+    {
+        ClearGrid();
+        gridSize = size;
+        cells = new Cell[size, size];
+
+        for (int y = 0; y < size; y++)
+        {
+            for (int x = 0; x < size; x++)
+            {
+                Cell cell = Instantiate(cellPrefab, gridRoot);
+                cell.Coordinates = new Vector2Int(x, y);
+                cells[x, y] = cell;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Removes all existing cells.
+    /// </summary>
+    private void ClearGrid()
+    {
+        if (cells == null)
+            return;
+
+        foreach (Cell c in cells)
+        {
+            if (c != null)
+                Destroy(c.gameObject);
+        }
+    }
+
+    /// <summary>
+    /// Returns a random empty cell, or null if none are available.
+    /// </summary>
+    public Cell GetRandomEmptyCell()
+    {
+        List<Cell> empty = new List<Cell>();
+        foreach (Cell c in cells)
+        {
+            if (!c.IsOccupied)
+                empty.Add(c);
+        }
+
+        if (empty.Count == 0)
+            return null;
+        int index = Random.Range(0, empty.Count);
+        return empty[index];
+    }
+
+    /// <summary>
+    /// Spawns a drop with the provided value on a random empty cell.
+    /// </summary>
+    public Drop SpawnDrop(int value)
+    {
+        Cell cell = GetRandomEmptyCell();
+        if (cell == null)
+            return null;
+
+        Drop drop = Instantiate(dropPrefab, cell.transform.position, Quaternion.identity, gridRoot);
+        drop.Initialize(value, cell);
+        return drop;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `GameManager` to manage state, score and ads
- implement `GridManager` for dynamic grid creation
- add `Cell` and `Drop` components for board elements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68618cb767e4832196039e221d6f73ae